### PR TITLE
Launch turtlebot3_nav_sim.launch.py from ros2 launch

### DIFF
--- a/src/turtlebot3_mypkg/CMakeLists.txt
+++ b/src/turtlebot3_mypkg/CMakeLists.txt
@@ -23,4 +23,8 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
 ament_package()


### PR DESCRIPTION
- turtlebot3_nav_sim.launch.pyを```ros2 launch```で起動できるようにCMakeLists.txtを修正した。