### PR TITLE
build.bashを削除

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,5 +1,0 @@
-#!/bin/bash
-rosdep update
-rosdep install -y -r -i --from-paths src --ignore-src --rosdistro $ROS_DISTRO
-colcon build --symlink-install
-


### PR DESCRIPTION
- build.bashを削除（理由; 使用していないため）